### PR TITLE
fix for hourly resource productions of > 999.999

### DIFF
--- a/Ogame UI++/src/utils/get-current-planet-resources.js
+++ b/Ogame UI++/src/utils/get-current-planet-resources.js
@@ -63,17 +63,17 @@ var fn = function () {
 
     resources.metal.now = dataResources.metal.amount;
     resources.metal.max = dataResources.metal.storage;
-    tmp = parseInt($($(dataResources.metal.tooltip.split('|')[1]).find('tr').get(2)).find('td span').text().replace(/\+|\-/i, '').replace(/\./,''));
+    tmp = parseInt($($(dataResources.metal.tooltip.split('|')[1]).find('tr').get(2)).find('td span').text().replace(/\+|\-/i, '').replace(/\./g,''));
     resources.metal.prod = tmp / 3600;
 
     resources.crystal.now = dataResources.crystal.amount;
     resources.crystal.max = dataResources.crystal.storage;
-    tmp = parseInt($($(dataResources.crystal.tooltip.split('|')[1]).find('tr').get(2)).find('td span').text().replace(/\+|\-/i, '').replace(/\./,''));
+    tmp = parseInt($($(dataResources.crystal.tooltip.split('|')[1]).find('tr').get(2)).find('td span').text().replace(/\+|\-/i, '').replace(/\./g,''));
     resources.crystal.prod = tmp / 3600;
 
     resources.deuterium.now = dataResources.deuterium.amount;
     resources.deuterium.max = dataResources.deuterium.storage;
-    tmp = parseInt($($(dataResources.deuterium.tooltip.split('|')[1]).find('tr').get(2)).find('td span').text().replace(/\+|\-/i, '').replace(/\./,''));
+    tmp = parseInt($($(dataResources.deuterium.tooltip.split('|')[1]).find('tr').get(2)).find('td span').text().replace(/\+|\-/i, '').replace(/\./g,''));
     resources.deuterium.prod = tmp / 3600;
 
     // if on the resources page, update the planet's resource levels


### PR DESCRIPTION
the replace function only replaces the first dot
example: 1.500.000 -> 1500.000
g flag removes all dots
example: 1.500.000 -> 1500000, as it should be